### PR TITLE
Added support for the Metadata template section

### DIFF
--- a/bin/csfn
+++ b/bin/csfn
@@ -28,6 +28,7 @@ fi
 
 (
 cat <<EOF
+Metadata={}
 Parameters={}
 Mappings={}
 Conditions={}
@@ -51,6 +52,7 @@ Template =
   AWSTemplateFormatVersion : "2010-09-09"
 
 Template.Description=Description if Description?
+Template.Metadata=Metadata if Object.keys(Metadata).length > 0
 Template.Parameters=Parameters if Object.keys(Parameters).length > 0
 Template.Mappings=Mappings if Object.keys(Mappings).length > 0
 Template.Conditions=Conditions if Object.keys(Conditions).length > 0


### PR DESCRIPTION
Cloudformation templates may optionally include a Metadata section, containing JSON objects that provide additional information about the template.  
I have added support for this section, placing it above "Parameters" and below "Description" in the final template, matching the order in the [template anatomy](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html) document.
